### PR TITLE
Added new AnsiUserType "Paintbrush-Bild"

### DIFF
--- a/OfficeExtractor/Ole/Ole10Native.cs
+++ b/OfficeExtractor/Ole/Ole10Native.cs
@@ -117,6 +117,7 @@ namespace OfficeExtractor.Ole
                     break;
 
                 case "PBrush":
+                case "Paintbrush-Bild":
                 case "Paintbrush-afbeelding":
                     var pbBrushSize = (int)ole10Native.Size - 4;
                     if (pbBrushSize <= 0)


### PR DESCRIPTION
We encountered an error "Unsupported OleNative AnsiUserType 'Paintbrush-Bild' found ...", adding "Paintbrush-Bild" to the AnsiUserTypes seems to do the job. The document used for testing can be found in the attachments
[redacted.docx](https://github.com/Sicos1977/OfficeExtractor/files/9132180/redacted.docx)
.